### PR TITLE
feat: 1:1 문의, 답변 기능 개발

### DIFF
--- a/seurasaeng_be/src/main/java/onehajo/seurasaeng/entity/Answer.java
+++ b/seurasaeng_be/src/main/java/onehajo/seurasaeng/entity/Answer.java
@@ -1,14 +1,12 @@
 package onehajo.seurasaeng.entity;
 
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.time.LocalDate;
-
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -35,14 +33,14 @@ public class Answer {
     @JoinColumn(name = "manager_id")
     private Manager manager;
 
-    @Lob
     @Column(name = "answer_content", columnDefinition = "TEXT")
     private String answer;
 
     @NotNull
     @Column(name = "answer_created_at", columnDefinition = "timestamp")
-    private LocalDate created_at;
+    private LocalDateTime created_at;
 
     // 생성자
     public Answer() {}
 }
+

--- a/seurasaeng_be/src/main/java/onehajo/seurasaeng/entity/Inquiry.java
+++ b/seurasaeng_be/src/main/java/onehajo/seurasaeng/entity/Inquiry.java
@@ -1,15 +1,13 @@
 package onehajo.seurasaeng.entity;
 
 import jakarta.persistence.*;
-import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.time.LocalDate;
-import java.util.spi.LocaleNameProvider;
+import java.time.LocalDateTime;
 
 
 @Entity
@@ -27,7 +25,7 @@ public class Inquiry {
 
     // 외래키 user_id
     @NotNull
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 
@@ -36,17 +34,12 @@ public class Inquiry {
     @NotBlank(message = "문의 제목은 필수 입력 값입니다.")
     private String title;
 
-    @Lob
     @Column(name = "inquiry_content", columnDefinition = "TEXT")
     private String content;
 
     @NotNull
     @Column(name = "inquiry_created_at", columnDefinition = "timestamp")
-    private LocalDate created_at;
-
-    @NotNull
-    @Column(name = "inquiry_updated_at", columnDefinition = "timestamp")
-    private LocalDate updated_at;
+    private LocalDateTime created_at;
 
     @NotNull
     @Column(name = "inquiry_answer_status", columnDefinition = "boolean default false")

--- a/seurasaeng_be/src/main/java/onehajo/seurasaeng/inquiry/controller/InquiryController.java
+++ b/seurasaeng_be/src/main/java/onehajo/seurasaeng/inquiry/controller/InquiryController.java
@@ -1,0 +1,77 @@
+package onehajo.seurasaeng.inquiry.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import onehajo.seurasaeng.entity.Inquiry;
+import onehajo.seurasaeng.inquiry.dto.AnswerReqDTO;
+import onehajo.seurasaeng.inquiry.dto.InquiryDetailResDTO;
+import onehajo.seurasaeng.inquiry.dto.InquiryReqDTO;
+import onehajo.seurasaeng.inquiry.dto.InquiryResDTO;
+import onehajo.seurasaeng.inquiry.service.InquiryService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/inquiries")
+public class InquiryController {
+    private final InquiryService inquiryService;
+
+    // 문의 생성
+    @PostMapping
+    public ResponseEntity<?> createInquiry(@RequestParam Long user_id, @RequestBody InquiryReqDTO inquiryReqDTO) {
+        InquiryDetailResDTO response = inquiryService.createInquiry(user_id, inquiryReqDTO);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(response);
+    }
+
+    // 사용자 별 문의 목록 조회
+    @GetMapping
+    public ResponseEntity<?> getInquiriesByUserId(@RequestParam Long user_id) {
+        List<InquiryResDTO> inquiryList = inquiryService.getInquiriesByUserId(user_id);
+
+        return ResponseEntity.ok(inquiryList);
+    }
+
+    @GetMapping("/admin")
+    public ResponseEntity<?> getInquiriesByManagerId(@RequestParam Long manager_id) {
+        List<InquiryResDTO> inquiryList = inquiryService.getInquiriesByManagerId(manager_id);
+
+        return ResponseEntity.ok(inquiryList);
+    }
+
+    // 문의 상세 조회
+    @GetMapping("/{id}")
+    public ResponseEntity<?> getInquiryDetail(@PathVariable Long id, @RequestParam Long user_id) {
+        InquiryDetailResDTO inquiry = inquiryService.getInquiryDetail(id, user_id);
+
+        return ResponseEntity.ok(inquiry);
+    }
+    
+    // 문의 삭제
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> deleteInquiryById(@PathVariable Long id, @RequestParam Long user_id) {
+        inquiryService.deleteInquiryById(id, user_id);
+
+        Map<String, String> response = Map.of(
+                "message", "문의를 삭제했습니다."
+        );
+
+        return ResponseEntity.ok(response);
+    }
+
+    // 답변 작성
+    @PostMapping("/{id}/answer")
+    public ResponseEntity<?> createAnswer(@PathVariable("id") Long id, @RequestParam Long manager_id, @RequestBody AnswerReqDTO request) {
+        InquiryDetailResDTO response = inquiryService.saveAnswer(id, manager_id, request);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(response);
+    }
+}

--- a/seurasaeng_be/src/main/java/onehajo/seurasaeng/inquiry/dto/AnswerReqDTO.java
+++ b/seurasaeng_be/src/main/java/onehajo/seurasaeng/inquiry/dto/AnswerReqDTO.java
@@ -1,0 +1,12 @@
+package onehajo.seurasaeng.inquiry.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AnswerReqDTO {
+    private String content;
+}

--- a/seurasaeng_be/src/main/java/onehajo/seurasaeng/inquiry/dto/AnswerResDTO.java
+++ b/seurasaeng_be/src/main/java/onehajo/seurasaeng/inquiry/dto/AnswerResDTO.java
@@ -1,0 +1,18 @@
+package onehajo.seurasaeng.inquiry.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AnswerResDTO {
+    private Long answer_id;
+    private String answer_content;
+    private LocalDateTime created_at;
+}

--- a/seurasaeng_be/src/main/java/onehajo/seurasaeng/inquiry/dto/InquiryDetailResDTO.java
+++ b/seurasaeng_be/src/main/java/onehajo/seurasaeng/inquiry/dto/InquiryDetailResDTO.java
@@ -1,0 +1,24 @@
+package onehajo.seurasaeng.inquiry.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class InquiryDetailResDTO {
+    private Long inquiry_id;
+    private String user_name;
+    private String title;
+    private String content;
+    private LocalDateTime created_at;
+    private boolean answer_status;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private AnswerResDTO answer;
+}

--- a/seurasaeng_be/src/main/java/onehajo/seurasaeng/inquiry/dto/InquiryReqDTO.java
+++ b/seurasaeng_be/src/main/java/onehajo/seurasaeng/inquiry/dto/InquiryReqDTO.java
@@ -1,0 +1,15 @@
+package onehajo.seurasaeng.inquiry.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class InquiryReqDTO {
+    private String title;
+    private String content;
+}

--- a/seurasaeng_be/src/main/java/onehajo/seurasaeng/inquiry/dto/InquiryResDTO.java
+++ b/seurasaeng_be/src/main/java/onehajo/seurasaeng/inquiry/dto/InquiryResDTO.java
@@ -1,0 +1,21 @@
+package onehajo.seurasaeng.inquiry.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class InquiryResDTO {
+    private Long id;
+    private String title;
+    private LocalDateTime created_at;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private boolean answer_status;
+}

--- a/seurasaeng_be/src/main/java/onehajo/seurasaeng/inquiry/exception/InquiryException.java
+++ b/seurasaeng_be/src/main/java/onehajo/seurasaeng/inquiry/exception/InquiryException.java
@@ -1,0 +1,7 @@
+package onehajo.seurasaeng.inquiry.exception;
+
+public class InquiryException extends RuntimeException {
+    public InquiryException(String message) {
+        super(message);
+    }
+}

--- a/seurasaeng_be/src/main/java/onehajo/seurasaeng/inquiry/exception/UserException.java
+++ b/seurasaeng_be/src/main/java/onehajo/seurasaeng/inquiry/exception/UserException.java
@@ -1,0 +1,7 @@
+package onehajo.seurasaeng.inquiry.exception;
+
+public class UserException extends RuntimeException {
+    public UserException(String message) {
+        super(message);
+    }
+}

--- a/seurasaeng_be/src/main/java/onehajo/seurasaeng/inquiry/repository/AnswerRepository.java
+++ b/seurasaeng_be/src/main/java/onehajo/seurasaeng/inquiry/repository/AnswerRepository.java
@@ -1,0 +1,14 @@
+package onehajo.seurasaeng.inquiry.repository;
+
+import onehajo.seurasaeng.entity.Answer;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface AnswerRepository extends JpaRepository<Answer, Long> {
+    Optional<Answer> findByInquiryId(Long inquiry_id);
+
+    void deleteByInquiryId(Long inquiry_id);
+}

--- a/seurasaeng_be/src/main/java/onehajo/seurasaeng/inquiry/repository/InquiryRepository.java
+++ b/seurasaeng_be/src/main/java/onehajo/seurasaeng/inquiry/repository/InquiryRepository.java
@@ -1,0 +1,21 @@
+package onehajo.seurasaeng.inquiry.repository;
+
+import onehajo.seurasaeng.entity.Inquiry;
+import onehajo.seurasaeng.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface InquiryRepository extends JpaRepository<Inquiry, Long> {
+    @Query("SELECT i FROM Inquiry i WHERE i.user = :user ORDER BY i.created_at DESC")
+    List<Inquiry> findByUserOrderByCreatedAtDesc(@Param("user") User user);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE Inquiry i SET i.answer_status = :status WHERE i.id = :inquiry_id")
+    void updateAnswerStatus(@Param("inquiry_id") Long inquiry_id, @Param("status") boolean status);
+}

--- a/seurasaeng_be/src/main/java/onehajo/seurasaeng/inquiry/repository/ManagerRepository.java
+++ b/seurasaeng_be/src/main/java/onehajo/seurasaeng/inquiry/repository/ManagerRepository.java
@@ -1,0 +1,9 @@
+package onehajo.seurasaeng.inquiry.repository;
+
+import onehajo.seurasaeng.entity.Manager;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ManagerRepository extends JpaRepository<Manager, Long> {
+}

--- a/seurasaeng_be/src/main/java/onehajo/seurasaeng/inquiry/service/InquiryService.java
+++ b/seurasaeng_be/src/main/java/onehajo/seurasaeng/inquiry/service/InquiryService.java
@@ -1,0 +1,227 @@
+package onehajo.seurasaeng.inquiry.service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import onehajo.seurasaeng.entity.Answer;
+import onehajo.seurasaeng.entity.Inquiry;
+import onehajo.seurasaeng.entity.Manager;
+import onehajo.seurasaeng.entity.User;
+import onehajo.seurasaeng.inquiry.dto.*;
+import onehajo.seurasaeng.inquiry.exception.InquiryException;
+import onehajo.seurasaeng.inquiry.exception.UserException;
+import onehajo.seurasaeng.inquiry.repository.AnswerRepository;
+import onehajo.seurasaeng.inquiry.repository.InquiryRepository;
+import onehajo.seurasaeng.inquiry.repository.ManagerRepository;
+import onehajo.seurasaeng.qr.exception.UserNotFoundException;
+import onehajo.seurasaeng.qr.repository.user.UserRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class InquiryService {
+    private final InquiryRepository inquiryRepository;
+    private final UserRepository userRepository;
+    private final AnswerRepository answerRepository;
+    private final ManagerRepository managerRepository;
+
+    // 문의 작성
+    public InquiryDetailResDTO createInquiry(Long user_id, InquiryReqDTO inquiryReqDTO) {
+        User user = validateUserExists(user_id);
+
+        Inquiry inquiry = buildInquiry(user, inquiryReqDTO);
+
+        Inquiry savedInquiry = inquiryRepository.save(inquiry);
+
+        return buildInquiryDetailResponse(savedInquiry, user_id, null);
+    }
+
+    // 사용자별 문의 목록 조회
+    public List<InquiryResDTO> getInquiriesByUserId(Long user_id) {
+        User user = validateUserExists(user_id);
+
+        List<Inquiry> inquiryList = inquiryRepository.findByUserOrderByCreatedAtDesc(user);
+
+        return inquiryList.stream()
+                .map(this::buildInquiryResponseWithStatus)
+                .collect(Collectors.toList());
+    }
+
+    // 관리자 - 문의 목록 전제 조회
+    public List<InquiryResDTO> getInquiriesByManagerId(Long manager_id) {
+        validateManagerExists(manager_id);
+
+        List<Inquiry> inquiryList = inquiryRepository.findAll();
+
+        return inquiryList.stream()
+                .map(this::buildInquiryResponseWithStatus)
+                .collect(Collectors.toList());
+    }
+
+    // 문의 상세 조회
+    public InquiryDetailResDTO getInquiryDetail(Long id, Long user_id) {
+        Inquiry inquiry = validateInquiryExists(id);
+
+        validateInquiryOwner(inquiry, user_id);
+
+        // answer_status가 true일 때 -> Answer 조회, false -> null
+        AnswerResDTO answerDTO = findAnswerByInquiry(inquiry);
+
+        return buildInquiryDetailResponse(inquiry, user_id, answerDTO);
+    }
+
+    // 문의 삭제
+    @Transactional
+    public void deleteInquiryById(Long id, Long user_id) {
+        try {
+            Inquiry inquiry = validateInquiryExists(id);
+
+            validateDeleteInquiryOwner(inquiry, user_id);
+
+            // 답변 내용이 있다면 답변 삭제
+            deleteAnswerIfExist(inquiry);
+
+            inquiryRepository.deleteById(id);
+        } catch (InquiryException | UserException | UserNotFoundException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("문의 삭제 실패 - inquiry_id : {}", id);
+            throw new RuntimeException("문의 삭제 실패", e);
+        }
+    }
+
+    // 답변 생성
+    @Transactional
+    public InquiryDetailResDTO saveAnswer(Long inquiry_id, Long manager_id, AnswerReqDTO request) {
+        Inquiry inquiry = validateInquiryExists(inquiry_id);
+        Manager manager = validateManagerExists(manager_id);
+
+        Answer answer = buildAnswer(inquiry, manager, request);
+        Answer savedAnswer = answerRepository.save(answer);
+        log.info("Answer 저장 완료 - answerId: {}", savedAnswer.getId());
+
+        inquiryRepository.updateAnswerStatus(inquiry_id, true);
+
+        Inquiry updatedInquiry = validateInquiryExists(inquiry_id);
+
+        AnswerResDTO answerDTO = buildAnswerResponse(savedAnswer);
+
+        return buildInquiryDetailResponse(updatedInquiry, updatedInquiry.getUser().getId(), answerDTO);
+    }
+
+    /** 유효성 검증
+     */
+    private User validateUserExists(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
+    }
+
+    private Inquiry validateInquiryExists(Long inquiry_id) {
+        return inquiryRepository.findById(inquiry_id)
+                .orElseThrow(() -> new InquiryException("문의를 찾을 수 없습니다."));
+    }
+
+    private Manager validateManagerExists(Long manager_id) {
+        return managerRepository.findById(manager_id)
+                .orElseThrow(() -> new IllegalArgumentException("관리자를 찾을 수 없습니다."));
+    }
+
+    private void validateInquiryOwner(Inquiry inquiry, Long user_id) {
+        if (!inquiry.getUser().getId().equals(user_id)) {
+            throw new UserException("본인의 문의만 접근할 수 있습니다.");
+        }
+    }
+
+    private void validateDeleteInquiryOwner(Inquiry inquiry, Long user_id) {
+        if (!inquiry.getUser().getId().equals(user_id)) {
+            throw new RuntimeException("본인의 문의만 삭제할 수 있습니다.");
+        }
+    }
+
+    /**
+     * 사용자 이름 가져오기
+     */
+    private String getUserName(Long user_id) {
+        return userRepository.findById(user_id).map(User::getName).orElse("알 수 없는 사용자입니다.");
+    }
+
+    /**
+     * builder 생성
+     */
+    private Inquiry buildInquiry(User user, InquiryReqDTO request) {
+        return Inquiry.builder()
+                .user(user)
+                .title(request.getTitle())
+                .content(request.getContent())
+                .created_at(LocalDateTime.now())
+                .answer_status(false)
+                .build();
+    }
+
+    private InquiryDetailResDTO buildInquiryDetailResponse(Inquiry inquiry, Long user_id, AnswerResDTO answerDto) {
+        return InquiryDetailResDTO.builder()
+                .inquiry_id(inquiry.getId())
+                .user_name(getUserName(user_id))
+                .title(inquiry.getTitle())
+                .content(inquiry.getContent())
+                .created_at(inquiry.getCreated_at())
+                .answer_status(inquiry.isAnswer_status())
+                .answer(answerDto)
+                .build();
+    }
+
+    private InquiryResDTO buildInquiryResponse(Inquiry inquiry) {
+        return InquiryResDTO.builder()
+                .id(inquiry.getId())
+                .title(inquiry.getTitle())
+                .created_at(inquiry.getCreated_at())
+                .build();
+    }
+
+    private InquiryResDTO buildInquiryResponseWithStatus(Inquiry inquiry) {
+        return InquiryResDTO.builder()
+                .id(inquiry.getId())
+                .title(inquiry.getTitle())
+                .created_at(inquiry.getCreated_at())
+                .answer_status(inquiry.isAnswer_status())
+                .build();
+    }
+
+    private Answer buildAnswer(Inquiry inquiry, Manager manager, AnswerReqDTO request) {
+        return Answer.builder()
+                .inquiry(inquiry)
+                .manager(manager)
+                .answer(request.getContent())
+                .created_at(LocalDateTime.now())
+                .build();
+    }
+
+    private AnswerResDTO buildAnswerResponse(Answer answer) {
+        return AnswerResDTO.builder()
+                .answer_id(answer.getId())
+                .answer_content(answer.getAnswer())
+                .created_at(answer.getCreated_at())
+                .build();
+    }
+
+    private AnswerResDTO findAnswerByInquiry(Inquiry inquiry) {
+        if(!inquiry.isAnswer_status()) {
+            return null;
+        }
+
+        return answerRepository.findByInquiryId(inquiry.getId())
+                .map(this::buildAnswerResponse)
+                .orElse(null);
+    }
+
+    private void deleteAnswerIfExist(Inquiry inquiry) {
+        if (inquiry.isAnswer_status()) {
+            answerRepository.deleteByInquiryId(inquiry.getId());
+        }
+    }
+}


### PR DESCRIPTION
📝작업 내용
1:1 문의, 답변 기능 구현
1) 사용자 1:1 문의 작성
2) 사용자별 문의 목록 조회
3) 사용자 문의 삭제 (답변이 있는 경우 답변과 함께 삭제)
4) 관리자 답변 작성
5) 관리자 1:1 문의 전체 조회
6) 문의 상세 조회


📋 추후 작업 사항
 - [ ] 단위 테스트 작성
 - [ ] 토큰 처리 추가
 - [ ] 상세 에러 핸들링 개선

⚠️ 수정 사항
 - Inquiry, Answer Entity 내 시간 관련 데이터 타입 변경(LocalDate -> LocalDateTime)
   - LocalDate => 시간 정보를 포함하지 않으므로 `날짜 + 시간` 모두 저장되는 LocalDateTime으로 변경
 - Inquiry, Answer Entity 내 @Lob 제거
   - columnDefinition = "TEXT"와 @Lob의 중복으로 postgre 내에서 해당 컬럼을 바이너리로 인식하여 @Lob 제거
 - Inquiry Entity 내 updated_at 제거
   - 문의 수정 기능 없으므로 해당 컬럼 제거
