### PR TITLE
셔틀 관련 API 작성 

### DIFF
--- a/seurasaeng_be/src/main/java/onehajo/seurasaeng/entity/Location.java
+++ b/seurasaeng_be/src/main/java/onehajo/seurasaeng/entity/Location.java
@@ -11,7 +11,7 @@ import lombok.*;
 @Getter
 @Builder
 @AllArgsConstructor
-@NoArgsConstructor (access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "location", schema = "seurasaeng_test")
 public class Location {
 

--- a/seurasaeng_be/src/main/java/onehajo/seurasaeng/entity/Location.java
+++ b/seurasaeng_be/src/main/java/onehajo/seurasaeng/entity/Location.java
@@ -1,9 +1,6 @@
 package onehajo.seurasaeng.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
@@ -16,6 +13,7 @@ import lombok.*;
 public class Location {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
     @Column(name = "location_id")
     private Long locationId;
 

--- a/seurasaeng_be/src/main/java/onehajo/seurasaeng/entity/Shuttle.java
+++ b/seurasaeng_be/src/main/java/onehajo/seurasaeng/entity/Shuttle.java
@@ -2,10 +2,7 @@ package onehajo.seurasaeng.entity;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -14,7 +11,7 @@ import java.util.List;
 @Getter
 @Builder
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "shuttle", schema = "seurasaeng_test")
 public class Shuttle {
 

--- a/seurasaeng_be/src/main/java/onehajo/seurasaeng/entity/Shuttle.java
+++ b/seurasaeng_be/src/main/java/onehajo/seurasaeng/entity/Shuttle.java
@@ -25,12 +25,12 @@ public class Shuttle {
     private String shuttleName;
 
     @NotNull
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "departure", referencedColumnName = "location_id")
     private Location departure;
 
     @NotNull
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "destination", referencedColumnName = "location_id")
     private Location destination;
 

--- a/seurasaeng_be/src/main/java/onehajo/seurasaeng/entity/Timetable.java
+++ b/seurasaeng_be/src/main/java/onehajo/seurasaeng/entity/Timetable.java
@@ -44,4 +44,8 @@ public class Timetable {
 
     @Column(name = "total_seats", columnDefinition = "INTEGER")
     private Integer totalSeats;
+
+    public void updateDepartureTime(LocalTime newTime) {
+        this.departureTime = newTime;
+    }
 }

--- a/seurasaeng_be/src/main/java/onehajo/seurasaeng/entity/Timetable.java
+++ b/seurasaeng_be/src/main/java/onehajo/seurasaeng/entity/Timetable.java
@@ -35,6 +35,10 @@ public class Timetable {
     @Column(name = "boarding_location", columnDefinition = "VARCHAR(100)")
     private String boardingLocation;
 
+    @NotNull
+    @Column(name = "dropoff_location", columnDefinition = "VARCHAR(100)")
+    private String dropoffLocation;
+
     @Column(name = "arrival_minutes", columnDefinition = "INTEGER")
     private Integer arrivalMinutes;
 

--- a/seurasaeng_be/src/main/java/onehajo/seurasaeng/entity/User.java
+++ b/seurasaeng_be/src/main/java/onehajo/seurasaeng/entity/User.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.*;
 import jakarta.validation.constraints.NotNull;
+import org.hibernate.annotations.ColumnDefault;
 
 
 @Entity
@@ -45,4 +46,16 @@ public class User {
     @Builder.Default
     @Column(name = "user_read_newnoti", columnDefinition = "boolean default false")
     private boolean read_newnoti = false;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "favorites_work_id")
+    @ColumnDefault("4")
+    private Shuttle favorites_work_id;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "favorites_home_id")
+    @ColumnDefault("9")
+    private Shuttle favorites_home_id;
 }

--- a/seurasaeng_be/src/main/java/onehajo/seurasaeng/qr/service/BoardingService.java
+++ b/seurasaeng_be/src/main/java/onehajo/seurasaeng/qr/service/BoardingService.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import onehajo.seurasaeng.qr.dto.BoardingRecordResDTO;
 import onehajo.seurasaeng.qr.repository.BoardingRepository;
-import onehajo.seurasaeng.qr.repository.shuttle.ShuttleRepository;
+import onehajo.seurasaeng.shuttle.repository.ShuttleRepository;
 import onehajo.seurasaeng.entity.Boarding;
 import onehajo.seurasaeng.entity.Shuttle;
 import org.springframework.data.redis.core.RedisTemplate;

--- a/seurasaeng_be/src/main/java/onehajo/seurasaeng/qr/service/QRService.java
+++ b/seurasaeng_be/src/main/java/onehajo/seurasaeng/qr/service/QRService.java
@@ -12,7 +12,7 @@ import onehajo.seurasaeng.qr.dto.ValidUserResDTO;
 import onehajo.seurasaeng.qr.exception.InvalidQRCodeException;
 import onehajo.seurasaeng.qr.exception.UserNotFoundException;
 import onehajo.seurasaeng.qr.repository.QrRepository;
-import onehajo.seurasaeng.qr.repository.shuttle.ShuttleRepository;
+import onehajo.seurasaeng.shuttle.repository.ShuttleRepository;
 import onehajo.seurasaeng.user.repository.UserRepository;
 import onehajo.seurasaeng.qr.util.AESUtil;
 import onehajo.seurasaeng.entity.Boarding;

--- a/seurasaeng_be/src/main/java/onehajo/seurasaeng/shuttle/controller/ShuttleController.java
+++ b/seurasaeng_be/src/main/java/onehajo/seurasaeng/shuttle/controller/ShuttleController.java
@@ -1,0 +1,37 @@
+package onehajo.seurasaeng.shuttle.controller;
+
+import lombok.RequiredArgsConstructor;
+import onehajo.seurasaeng.shuttle.dto.ShuttleResponseDto;
+import onehajo.seurasaeng.shuttle.dto.ShuttleWithLocationResponseDto;
+import onehajo.seurasaeng.shuttle.service.ShuttleService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/shuttles")
+public class ShuttleController {
+    private final ShuttleService shuttleService;
+
+    @GetMapping
+    public ResponseEntity<List<ShuttleResponseDto>> getShuttles() {
+        List<ShuttleResponseDto> shuttleList = shuttleService.getShuttleList();
+        if (shuttleList.isEmpty()) {
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.ok(shuttleList);
+    }
+
+    @GetMapping("/locations")
+    public ResponseEntity<List<ShuttleWithLocationResponseDto>> getShuttlesWithLocation() {
+        List<ShuttleWithLocationResponseDto> shuttleList = shuttleService.getShuttleWithLocation();
+        if (shuttleList.isEmpty()) {
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.ok(shuttleList);
+    }
+}

--- a/seurasaeng_be/src/main/java/onehajo/seurasaeng/shuttle/controller/TimetableController.java
+++ b/seurasaeng_be/src/main/java/onehajo/seurasaeng/shuttle/controller/TimetableController.java
@@ -1,19 +1,21 @@
 package onehajo.seurasaeng.shuttle.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import onehajo.seurasaeng.shuttle.dto.TimetableResponseDto;
+import onehajo.seurasaeng.shuttle.dto.UpdateTimetableRequestDto;
 import onehajo.seurasaeng.shuttle.service.TimetableService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/timetables")
+@RequestMapping("/api")
 public class TimetableController {
 
     private final TimetableService timetableService;
 
-    @GetMapping
+    @GetMapping("/timetables")
     public ResponseEntity<TimetableResponseDto> getTimetable() {
         TimetableResponseDto response = timetableService.getTimetable();
 
@@ -22,5 +24,11 @@ public class TimetableController {
             return ResponseEntity.noContent().build();
         }
         return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/timetable")
+    public ResponseEntity<Void> updateTimetable(@RequestBody @Valid UpdateTimetableRequestDto request) {
+        timetableService.updateTimetable(request);
+        return ResponseEntity.ok().build();
     }
 }

--- a/seurasaeng_be/src/main/java/onehajo/seurasaeng/shuttle/controller/TimetableController.java
+++ b/seurasaeng_be/src/main/java/onehajo/seurasaeng/shuttle/controller/TimetableController.java
@@ -1,0 +1,26 @@
+package onehajo.seurasaeng.shuttle.controller;
+
+import lombok.RequiredArgsConstructor;
+import onehajo.seurasaeng.shuttle.dto.TimetableResponseDto;
+import onehajo.seurasaeng.shuttle.service.TimetableService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/timetables")
+public class TimetableController {
+
+    private final TimetableService timetableService;
+
+    @GetMapping
+    public ResponseEntity<TimetableResponseDto> getTimetable() {
+        TimetableResponseDto response = timetableService.getTimetable();
+
+        if ((response.getCommute() == null || response.getCommute().isEmpty()) &&
+                (response.getOffwork() == null || response.getOffwork().isEmpty())) {
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.ok(response);
+    }
+}

--- a/seurasaeng_be/src/main/java/onehajo/seurasaeng/shuttle/dto/ShuttleResponseDto.java
+++ b/seurasaeng_be/src/main/java/onehajo/seurasaeng/shuttle/dto/ShuttleResponseDto.java
@@ -1,0 +1,14 @@
+package onehajo.seurasaeng.shuttle.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ShuttleResponseDto {
+    private Long id;
+    private String shuttleName;
+    private String departureName;
+    private String destinationName;
+    private Boolean commute;
+}

--- a/seurasaeng_be/src/main/java/onehajo/seurasaeng/shuttle/dto/ShuttleWithLocationResponseDto.java
+++ b/seurasaeng_be/src/main/java/onehajo/seurasaeng/shuttle/dto/ShuttleWithLocationResponseDto.java
@@ -1,0 +1,18 @@
+package onehajo.seurasaeng.shuttle.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ShuttleWithLocationResponseDto {
+    private Long id;
+    private String shuttleName;
+    private String departureName;
+    private Double departureLatitude;
+    private Double departureLongitude;
+    private String destinationName;
+    private Double destinationLatitude;
+    private Double destinationLongitude;
+    private Boolean commute;
+}

--- a/seurasaeng_be/src/main/java/onehajo/seurasaeng/shuttle/dto/ShuttleWithTimetableDto.java
+++ b/seurasaeng_be/src/main/java/onehajo/seurasaeng/shuttle/dto/ShuttleWithTimetableDto.java
@@ -1,0 +1,19 @@
+package onehajo.seurasaeng.shuttle.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ShuttleWithTimetableDto {
+    private Long shuttleId;          // 노선 ID
+    private String shuttleName;      // 셔틀명
+    private String spotName;         // 거점 (출발지 or 도착지)
+    private String duration;         // 소요시간 ("15분")
+    private String totalSeats;       // 총인원수 ("45명")
+    private String boardingPoint;    // 탑승 장소 (출발/도착 장소)
+    private List<TimetableDto> timetables; // 시간표 리스트
+
+}

--- a/seurasaeng_be/src/main/java/onehajo/seurasaeng/shuttle/dto/TimetableDto.java
+++ b/seurasaeng_be/src/main/java/onehajo/seurasaeng/shuttle/dto/TimetableDto.java
@@ -1,0 +1,12 @@
+package onehajo.seurasaeng.shuttle.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+
+@Getter
+@Builder
+public class TimetableDto {
+    private String turn;          // "1회", "2회"
+    private String departureTime; // "07:20"
+}

--- a/seurasaeng_be/src/main/java/onehajo/seurasaeng/shuttle/dto/TimetableResponseDto.java
+++ b/seurasaeng_be/src/main/java/onehajo/seurasaeng/shuttle/dto/TimetableResponseDto.java
@@ -1,0 +1,13 @@
+package onehajo.seurasaeng.shuttle.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class TimetableResponseDto {
+    private List<ShuttleWithTimetableDto> commute; // 출근
+    private List<ShuttleWithTimetableDto> offwork; // 퇴근
+}

--- a/seurasaeng_be/src/main/java/onehajo/seurasaeng/shuttle/dto/UpdateTimetableRequestDto.java
+++ b/seurasaeng_be/src/main/java/onehajo/seurasaeng/shuttle/dto/UpdateTimetableRequestDto.java
@@ -1,0 +1,33 @@
+package onehajo.seurasaeng.shuttle.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateTimetableRequestDto {
+
+    @NotNull
+    private Long shuttleId;
+
+    @NotEmpty
+    private List<TimetableDto> timetables;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TimetableDto {
+        @NotBlank
+        private String turn;
+
+        @NotBlank
+        private String departureTime; // (HH:mm)
+    }
+}

--- a/seurasaeng_be/src/main/java/onehajo/seurasaeng/shuttle/exception/InvalidTimetableSizeException.java
+++ b/seurasaeng_be/src/main/java/onehajo/seurasaeng/shuttle/exception/InvalidTimetableSizeException.java
@@ -1,0 +1,7 @@
+package onehajo.seurasaeng.shuttle.exception;
+
+public class InvalidTimetableSizeException extends RuntimeException {
+    public InvalidTimetableSizeException() {
+        super("기존 시간표 개수와 요청한 시간표 개수가 다릅니다.");
+    }
+}

--- a/seurasaeng_be/src/main/java/onehajo/seurasaeng/shuttle/exception/ShuttleNotFoundException.java
+++ b/seurasaeng_be/src/main/java/onehajo/seurasaeng/shuttle/exception/ShuttleNotFoundException.java
@@ -1,0 +1,7 @@
+package onehajo.seurasaeng.shuttle.exception;
+
+public class ShuttleNotFoundException extends RuntimeException {
+    public ShuttleNotFoundException(Long shuttleId) {
+        super("해당 셔틀 노선을 찾을 수 없습니다. ID=" + shuttleId);
+    }
+}

--- a/seurasaeng_be/src/main/java/onehajo/seurasaeng/shuttle/repository/LocationRepository.java
+++ b/seurasaeng_be/src/main/java/onehajo/seurasaeng/shuttle/repository/LocationRepository.java
@@ -1,0 +1,9 @@
+package onehajo.seurasaeng.shuttle.repository;
+
+import onehajo.seurasaeng.entity.Location;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LocationRepository extends JpaRepository<Location, Long>{
+}

--- a/seurasaeng_be/src/main/java/onehajo/seurasaeng/shuttle/repository/ShuttleRepository.java
+++ b/seurasaeng_be/src/main/java/onehajo/seurasaeng/shuttle/repository/ShuttleRepository.java
@@ -1,4 +1,4 @@
-package onehajo.seurasaeng.qr.repository.shuttle;
+package onehajo.seurasaeng.shuttle.repository;
 
 import onehajo.seurasaeng.entity.Shuttle;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/seurasaeng_be/src/main/java/onehajo/seurasaeng/shuttle/repository/ShuttleRepository.java
+++ b/seurasaeng_be/src/main/java/onehajo/seurasaeng/shuttle/repository/ShuttleRepository.java
@@ -4,6 +4,9 @@ import onehajo.seurasaeng.entity.Shuttle;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface ShuttleRepository extends JpaRepository<Shuttle, Long> {
+    List<Shuttle> findByIsCommute(Boolean isCommute);
 }

--- a/seurasaeng_be/src/main/java/onehajo/seurasaeng/shuttle/repository/TimetableRepository.java
+++ b/seurasaeng_be/src/main/java/onehajo/seurasaeng/shuttle/repository/TimetableRepository.java
@@ -8,5 +8,5 @@ import java.util.List;
 
 public interface TimetableRepository extends JpaRepository<Timetable, Long> {
     List<Timetable> findByShuttleOrderByDepartureTimeAsc(Shuttle shuttle);
-
+    void deleteByShuttle(Shuttle shuttle);
 }

--- a/seurasaeng_be/src/main/java/onehajo/seurasaeng/shuttle/repository/TimetableRepository.java
+++ b/seurasaeng_be/src/main/java/onehajo/seurasaeng/shuttle/repository/TimetableRepository.java
@@ -1,0 +1,12 @@
+package onehajo.seurasaeng.shuttle.repository;
+
+import onehajo.seurasaeng.entity.Shuttle;
+import onehajo.seurasaeng.entity.Timetable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface TimetableRepository extends JpaRepository<Timetable, Long> {
+    List<Timetable> findByShuttleOrderByDepartureTimeAsc(Shuttle shuttle);
+
+}

--- a/seurasaeng_be/src/main/java/onehajo/seurasaeng/shuttle/service/ShuttleService.java
+++ b/seurasaeng_be/src/main/java/onehajo/seurasaeng/shuttle/service/ShuttleService.java
@@ -1,0 +1,48 @@
+package onehajo.seurasaeng.shuttle.service;
+
+import lombok.RequiredArgsConstructor;
+import onehajo.seurasaeng.entity.Shuttle;
+import onehajo.seurasaeng.shuttle.dto.ShuttleResponseDto;
+import onehajo.seurasaeng.shuttle.dto.ShuttleWithLocationResponseDto;
+import onehajo.seurasaeng.shuttle.repository.ShuttleRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ShuttleService {
+    private final ShuttleRepository shuttleRepository;
+
+    public List<ShuttleResponseDto> getShuttleList() {
+        List<Shuttle> shuttles = shuttleRepository.findAll();
+
+        return shuttles.stream()
+                .map(shuttle -> ShuttleResponseDto.builder()
+                        .id(shuttle.getId())
+                        .shuttleName(shuttle.getShuttleName())
+                        .departureName(shuttle.getDeparture().getLocationName())
+                        .destinationName(shuttle.getDestination().getLocationName())
+                        .commute(shuttle.getIsCommute())
+                        .build())
+                .toList();
+    }
+
+    public List<ShuttleWithLocationResponseDto> getShuttleWithLocation() {
+        List<Shuttle> shuttles = shuttleRepository.findAll();
+
+        return shuttles.stream()
+                .map(shuttle -> ShuttleWithLocationResponseDto.builder()
+                        .id(shuttle.getId())
+                        .shuttleName(shuttle.getShuttleName())
+                        .departureName(shuttle.getDeparture().getLocationName())
+                        .departureLongitude(shuttle.getDeparture().getLongitude())
+                        .departureLatitude(shuttle.getDeparture().getLatitude())
+                        .destinationName(shuttle.getDestination().getLocationName())
+                        .destinationLongitude(shuttle.getDestination().getLongitude())
+                        .destinationLatitude(shuttle.getDestination().getLatitude())
+                        .commute(shuttle.getIsCommute())
+                        .build())
+                .toList();
+    }
+}

--- a/seurasaeng_be/src/main/java/onehajo/seurasaeng/shuttle/service/TimetableService.java
+++ b/seurasaeng_be/src/main/java/onehajo/seurasaeng/shuttle/service/TimetableService.java
@@ -1,0 +1,107 @@
+package onehajo.seurasaeng.shuttle.service;
+
+import lombok.RequiredArgsConstructor;
+import onehajo.seurasaeng.entity.Shuttle;
+import onehajo.seurasaeng.entity.Timetable;
+import onehajo.seurasaeng.shuttle.dto.ShuttleWithTimetableDto;
+import onehajo.seurasaeng.shuttle.dto.TimetableDto;
+import onehajo.seurasaeng.shuttle.dto.TimetableResponseDto;
+import onehajo.seurasaeng.shuttle.repository.ShuttleRepository;
+import onehajo.seurasaeng.shuttle.repository.TimetableRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TimetableService {
+
+    private final ShuttleRepository shuttleRepository;
+    private final TimetableRepository timetableRepository;
+
+    public TimetableResponseDto getTimetable() {
+        List<ShuttleWithTimetableDto> commuteShuttles = buildTimetableList(true); // 출근 셔틀 목록
+        List<ShuttleWithTimetableDto> offworkShuttles = buildTimetableList(false); // 퇴근 셔틀 목록
+
+        return TimetableResponseDto.builder()
+                .commute(commuteShuttles)
+                .offwork(offworkShuttles)
+                .build();
+    }
+
+    private List<ShuttleWithTimetableDto> buildTimetableList(boolean isCommute) {
+        // 출근 또는 퇴근 셔틀 조회
+        List<Shuttle> shuttles = shuttleRepository.findByIsCommute(isCommute);
+        List<ShuttleWithTimetableDto> shuttleWithTimetableDtoList = new ArrayList<>();
+
+        for (Shuttle shuttle : shuttles) {
+            List<Timetable> timetables = timetableRepository.findByShuttleOrderByDepartureTimeAsc(shuttle);
+
+            // 시간표가 없으면 건너뜀
+            if (timetables == null || timetables.isEmpty()) {
+                continue;
+            }
+
+            Timetable firstTimetable = timetables.getFirst(); // 첫 번째 시간표
+
+            // 출근이면 출발지, 퇴근이면 도착지
+            String spotName = "";
+            if (isCommute) {
+                spotName = shuttle.getDeparture().getLocationName();
+            } else {
+                spotName = shuttle.getDestination().getLocationName();
+            }
+
+            // 출근이면 boardingLocation, 퇴근이면 dropoffLocation
+            String boardingPoint = "";
+            if (isCommute) {
+                boardingPoint = firstTimetable.getBoardingLocation();
+            } else {
+                boardingPoint = firstTimetable.getDropoffLocation();
+            }
+
+            // 시간표 DTO 변환
+            List<TimetableDto> timetableDtos = new ArrayList<>();
+            for (int i = 0; i < timetables.size(); i++) {
+                Timetable timetable = timetables.get(i);
+
+                TimetableDto timetableDto = TimetableDto.builder()
+                        .turn((i + 1) + "회") // 1회, 2회 형식
+                        .departureTime(timetable.getDepartureTime().toString().substring(0, 5)) // "HH:mm" 포맷
+                        .build();
+
+                timetableDtos.add(timetableDto);
+            }
+
+            // 셔틀 + 시간표 DTO 구성
+            ShuttleWithTimetableDto shuttleWithTimetableDto = ShuttleWithTimetableDto.builder()
+                    .shuttleId(shuttle.getId())
+                    .shuttleName(shuttle.getShuttleName())
+                    .spotName(spotName)
+                    .duration(formatDuration(firstTimetable.getArrivalMinutes()))
+                    .totalSeats(formatTotalSeats(firstTimetable.getTotalSeats()))
+                    .boardingPoint(boardingPoint)
+                    .timetables(timetableDtos)
+                    .build();
+
+            shuttleWithTimetableDtoList.add(shuttleWithTimetableDto);
+        }
+
+        return shuttleWithTimetableDtoList;
+    }
+
+    private String formatDuration(Integer minutes) {
+        if (minutes == null) {
+            return "";
+        }
+        return minutes + "분";
+    }
+
+    private String formatTotalSeats(Integer seats) {
+        if (seats == null) {
+            return "";
+        }
+        return seats + "명";
+    }
+}

--- a/seurasaeng_be/src/main/java/onehajo/seurasaeng/user/controller/UserController.java
+++ b/seurasaeng_be/src/main/java/onehajo/seurasaeng/user/controller/UserController.java
@@ -96,4 +96,10 @@ public class UserController {
 
         return new ResponseEntity<MyInfoResDTO>(myInfoResDTO, HttpStatus.OK);
     }
+
+    @GetMapping("/me/preferences")
+    public ResponseEntity<FavoriteShuttleResDto> getFavorites(HttpServletRequest request) {
+        FavoriteShuttleResDto response = userService.getFavoriteShuttleIds(request);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/seurasaeng_be/src/main/java/onehajo/seurasaeng/user/dto/FavoriteShuttleResDto.java
+++ b/seurasaeng_be/src/main/java/onehajo/seurasaeng/user/dto/FavoriteShuttleResDto.java
@@ -1,0 +1,11 @@
+package onehajo.seurasaeng.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FavoriteShuttleResDto {
+    private Long favoritesWorkId;  // 출근 즐겨찾기 노선 ID
+    private Long favoritesHomeId;  // 퇴근 즐겨찾기 노선 ID
+}

--- a/seurasaeng_be/src/main/java/onehajo/seurasaeng/user/service/UserService.java
+++ b/seurasaeng_be/src/main/java/onehajo/seurasaeng/user/service/UserService.java
@@ -4,6 +4,7 @@ import jakarta.persistence.EntityNotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.transaction.Transactional;
 import onehajo.seurasaeng.entity.User;
+import onehajo.seurasaeng.qr.exception.UserNotFoundException;
 import onehajo.seurasaeng.redis.service.RedisTokenService;
 import onehajo.seurasaeng.user.exception.*;
 import onehajo.seurasaeng.user.repository.UserRepository;
@@ -131,6 +132,18 @@ public class UserService {
         return MyInfoResDTO.builder()
                 .name(user.getName())
                 //.image(user.getImage())
+                .build();
+    }
+
+    public FavoriteShuttleResDto getFavoriteShuttleIds(HttpServletRequest request) {
+        String token = request.getHeader("Authorization").replace("Bearer ", "");
+        Long id = jwtUtil.getIdFromToken(token);
+
+        User user = userRepository.findById(id).orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
+
+        return FavoriteShuttleResDto.builder()
+                .favoritesWorkId(user.getFavorites_work_id().getId())
+                .favoritesHomeId(user.getFavorites_home_id().getId())
                 .build();
     }
 }

--- a/seurasaeng_be/src/main/java/onehajo/seurasaeng/util/GlobalExceptionHandler.java
+++ b/seurasaeng_be/src/main/java/onehajo/seurasaeng/util/GlobalExceptionHandler.java
@@ -3,8 +3,11 @@ package onehajo.seurasaeng.util;
 import lombok.extern.slf4j.Slf4j;
 import onehajo.seurasaeng.qr.exception.InvalidQRCodeException;
 import onehajo.seurasaeng.qr.exception.UserNotFoundException;
+import onehajo.seurasaeng.shuttle.exception.InvalidTimetableSizeException;
+import onehajo.seurasaeng.shuttle.exception.ShuttleNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -48,4 +51,19 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(Map.of("error", "예상치 못한 오류입니다."));
     }
+
+
+    @ExceptionHandler(ShuttleNotFoundException.class)
+    public ResponseEntity<Map<String, String>> handleShuttleNotFound(Exception e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(Map.of("error",  e.getMessage()));
+    }
+
+    @ExceptionHandler(InvalidTimetableSizeException.class)
+    public ResponseEntity<Map<String, String>> handleInvalidTimetableSize(Exception e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(Map.of("error", e.getMessage()));
+    }
+
+
 }

--- a/seurasaeng_be/src/test/java/onehajo/seurasaeng/qr/BoardingServiceTest.java
+++ b/seurasaeng_be/src/test/java/onehajo/seurasaeng/qr/BoardingServiceTest.java
@@ -3,7 +3,7 @@ package onehajo.seurasaeng.qr;
 import onehajo.seurasaeng.entity.Location;
 import onehajo.seurasaeng.qr.dto.BoardingRecordResDTO;
 import onehajo.seurasaeng.qr.repository.BoardingRepository;
-import onehajo.seurasaeng.qr.repository.shuttle.ShuttleRepository;
+import onehajo.seurasaeng.shuttle.repository.ShuttleRepository;
 import onehajo.seurasaeng.qr.service.BoardingService;
 import onehajo.seurasaeng.entity.Boarding;
 import onehajo.seurasaeng.entity.Shuttle;

--- a/seurasaeng_be/src/test/java/onehajo/seurasaeng/shuttle/FavoriteShuttleIntegrationTest.java
+++ b/seurasaeng_be/src/test/java/onehajo/seurasaeng/shuttle/FavoriteShuttleIntegrationTest.java
@@ -1,0 +1,97 @@
+package onehajo.seurasaeng.shuttle;
+
+import jakarta.transaction.Transactional;
+import onehajo.seurasaeng.entity.Location;
+import onehajo.seurasaeng.entity.Shuttle;
+import onehajo.seurasaeng.entity.User;
+import onehajo.seurasaeng.shuttle.repository.LocationRepository;
+import onehajo.seurasaeng.shuttle.repository.ShuttleRepository;
+import onehajo.seurasaeng.user.repository.UserRepository;
+import onehajo.seurasaeng.util.JwtUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@Transactional
+public class FavoriteShuttleIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ShuttleRepository shuttleRepository;
+
+    @Autowired
+    private LocationRepository locationRepository;
+
+    @Autowired
+    private JwtUtil jwtUtil;
+
+    private String token;
+
+    @BeforeEach
+    void setUp() {
+        Location departure = locationRepository.save(Location.builder()
+                .locationName("정부과천청사역")
+                .latitude(37.4254)
+                .longitude(126.9892)
+                .build());
+
+        Location destination = locationRepository.save(Location.builder()
+                .locationName("아이티센타워")
+                .latitude(37.5013)
+                .longitude(127.0396)
+                .build());
+
+        Shuttle commuteShuttle = shuttleRepository.save(Shuttle.builder()
+                .shuttleName("출근 셔틀")
+                .departure(departure)
+                .destination(destination)
+                .isCommute(true)
+                .build());
+
+        Shuttle offworkShuttle = shuttleRepository.save(Shuttle.builder()
+                .shuttleName("퇴근 셔틀")
+                .departure(destination)
+                .destination(departure)
+                .isCommute(false)
+                .build());
+
+        User user = User.builder()
+                .name("홍길동")
+                .email("hong@test.com")
+                .password("password")
+                .favorites_work_id(commuteShuttle)
+                .favorites_home_id(offworkShuttle)
+                .build();
+
+        userRepository.save(user);
+
+        token = jwtUtil.generateToken(user.getId(), user.getName(), user.getEmail());
+    }
+
+    @Test
+    @DisplayName("즐겨찾기 조회 API - 통합테스트 | 정상 200 OK")
+    void getFavoriteShuttleSuccess() throws Exception {
+        mockMvc.perform(get("/api/users/me/preferences")
+                        .header("Authorization", "Bearer " + token)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.favoritesWorkId").exists())
+                .andExpect(jsonPath("$.favoritesHomeId").exists());
+    }
+}

--- a/seurasaeng_be/src/test/java/onehajo/seurasaeng/shuttle/FavoriteShuttleServiceUnitTest.java
+++ b/seurasaeng_be/src/test/java/onehajo/seurasaeng/shuttle/FavoriteShuttleServiceUnitTest.java
@@ -1,0 +1,71 @@
+package onehajo.seurasaeng.shuttle;
+
+import jakarta.servlet.http.HttpServletRequest;
+import onehajo.seurasaeng.entity.Shuttle;
+import onehajo.seurasaeng.entity.User;
+import onehajo.seurasaeng.user.dto.FavoriteShuttleResDto;
+import onehajo.seurasaeng.user.repository.UserRepository;
+import onehajo.seurasaeng.util.JwtUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class FavoriteShuttleServiceUnitTest {
+
+    @InjectMocks
+    private onehajo.seurasaeng.user.service.UserService userService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private JwtUtil jwtUtil;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Test
+    @DisplayName("즐겨찾기 조회 - 단위테스트")
+    void getFavoriteShuttleIdsTest() {
+
+        Shuttle commuteShuttle = Shuttle.builder()
+                .id(1L)
+                .shuttleName("출근 셔틀")
+                .build();
+
+        Shuttle offworkShuttle = Shuttle.builder()
+                .id(2L)
+                .shuttleName("퇴근 셔틀")
+                .build();
+
+        User user = User.builder()
+                .id(100L)
+                .name("홍길동")
+                .email("hong@test.com")
+                .password("password")
+                .favorites_work_id(commuteShuttle)
+                .favorites_home_id(offworkShuttle)
+                .build();
+
+        String token = "mockToken";
+        when(request.getHeader("Authorization")).thenReturn("Bearer " + token);
+        when(jwtUtil.getIdFromToken(token)).thenReturn(100L);
+        when(userRepository.findById(100L)).thenReturn(java.util.Optional.of(user));
+
+        FavoriteShuttleResDto response = userService.getFavoriteShuttleIds(request);
+
+        assertThat(response.getFavoritesWorkId()).isEqualTo(1L);
+        assertThat(response.getFavoritesHomeId()).isEqualTo(2L);
+
+        verify(jwtUtil, times(1)).getIdFromToken(token);
+        verify(userRepository, times(1)).findById(100L);
+    }
+}

--- a/seurasaeng_be/src/test/java/onehajo/seurasaeng/shuttle/ShuttleIntegrationTest.java
+++ b/seurasaeng_be/src/test/java/onehajo/seurasaeng/shuttle/ShuttleIntegrationTest.java
@@ -61,8 +61,8 @@ public class ShuttleIntegrationTest {
     }
 
     @Test
-    @DisplayName("노선 목록 조회 API - 통합테스트")
-    void testGetShutltes() throws Exception {
+    @DisplayName("노선 목록 조회 API - 통합테스트 | 데이터 존재시 200 OK")
+    void testGetShuttles() throws Exception {
         mockMvc.perform(get("/api/shuttles")
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
@@ -73,7 +73,18 @@ public class ShuttleIntegrationTest {
     }
 
     @Test
-    @DisplayName("노선 위치 정보 포함 목록 조회 API - 통합테스트")
+    @DisplayName("노선 목록 조회 API - 통합테스트 | 데이터 없을 시 204 No Content")
+    void testGetShuttles_No_Content() throws Exception {
+        shuttleRepository.deleteAll();
+        locationRepository.deleteAll();
+
+        mockMvc.perform(get("/api/shuttles")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("위치 정보 포함 노선 목록 조회 API - 통합테스트 | 데이터 존재시 200 OK")
     void testGetShuttlesWithLocation() throws Exception {
         mockMvc.perform(get("/api/shuttles/locations")
                         .accept(MediaType.APPLICATION_JSON))
@@ -82,5 +93,16 @@ public class ShuttleIntegrationTest {
                 .andExpect(jsonPath("$[0].departureLongitude").value(126.9780))
                 .andExpect(jsonPath("$[0].destinationLatitude").value(37.5665))
                 .andExpect(jsonPath("$[0].destinationLongitude").value(126.9780));
+    }
+
+    @Test
+    @DisplayName("위치 정보 포함 노선 목록 조회 API - 통합테스트 | 데이터 없을 시 204 No Content")
+    void testGetShuttlesWithLocation_No_Content() throws Exception {
+        shuttleRepository.deleteAll();
+        locationRepository.deleteAll();
+
+        mockMvc.perform(get("/api/shuttles/locations")
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNoContent());
     }
 }

--- a/seurasaeng_be/src/test/java/onehajo/seurasaeng/shuttle/ShuttleIntegrationTest.java
+++ b/seurasaeng_be/src/test/java/onehajo/seurasaeng/shuttle/ShuttleIntegrationTest.java
@@ -1,0 +1,86 @@
+package onehajo.seurasaeng.shuttle;
+
+import jakarta.transaction.Transactional;
+import onehajo.seurasaeng.entity.Location;
+import onehajo.seurasaeng.entity.Shuttle;
+import onehajo.seurasaeng.shuttle.repository.LocationRepository;
+import onehajo.seurasaeng.shuttle.repository.ShuttleRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@Transactional
+public class ShuttleIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ShuttleRepository shuttleRepository;
+
+    @Autowired
+    private LocationRepository locationRepository;
+
+    @BeforeEach
+    void setup() {
+        Location departure = Location.builder()
+                .locationId(1L)
+                .locationName("아이티센타워")
+                .latitude(37.5665)
+                .longitude(126.9780)
+                .build();
+
+        Location destination = Location.builder()
+                .locationId(2L)
+                .locationName("양재역")
+                .latitude(37.5665)
+                .longitude(126.9780)
+                .build();
+
+        departure = locationRepository.save(departure);
+        destination = locationRepository.save(destination);
+
+        Shuttle shuttle = Shuttle.builder()
+                .shuttleName("양재")
+                .departure(departure)
+                .destination(destination)
+                .isCommute(true)
+                .build();
+        shuttleRepository.save(shuttle);
+    }
+
+    @Test
+    @DisplayName("노선 목록 조회 API - 통합테스트")
+    void testGetShutltes() throws Exception {
+        mockMvc.perform(get("/api/shuttles")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].shuttleName").value("양재"))
+                .andExpect(jsonPath("$[0].departureName").value("아이티센타워"))
+                .andExpect(jsonPath("$[0].destinationName").value("양재역"))
+                .andExpect(jsonPath("$[0].commute").value(true));
+    }
+
+    @Test
+    @DisplayName("노선 위치 정보 포함 목록 조회 API - 통합테스트")
+    void testGetShuttlesWithLocation() throws Exception {
+        mockMvc.perform(get("/api/shuttles/locations")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].departureLatitude").value(37.5665))
+                .andExpect(jsonPath("$[0].departureLongitude").value(126.9780))
+                .andExpect(jsonPath("$[0].destinationLatitude").value(37.5665))
+                .andExpect(jsonPath("$[0].destinationLongitude").value(126.9780));
+    }
+}

--- a/seurasaeng_be/src/test/java/onehajo/seurasaeng/shuttle/ShuttleServiceUnitTest.java
+++ b/seurasaeng_be/src/test/java/onehajo/seurasaeng/shuttle/ShuttleServiceUnitTest.java
@@ -1,0 +1,89 @@
+package onehajo.seurasaeng.shuttle;
+
+import onehajo.seurasaeng.entity.Location;
+import onehajo.seurasaeng.entity.Shuttle;
+import onehajo.seurasaeng.shuttle.dto.ShuttleResponseDto;
+import onehajo.seurasaeng.shuttle.dto.ShuttleWithLocationResponseDto;
+import onehajo.seurasaeng.shuttle.repository.ShuttleRepository;
+import onehajo.seurasaeng.shuttle.service.ShuttleService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ShuttleServiceUnitTest {
+
+    @InjectMocks
+    private ShuttleService shuttleService;
+
+    @Mock
+    private ShuttleRepository shuttleRepository;
+
+    private Shuttle shuttle;
+
+    @BeforeEach
+    void setup() {
+        Location departure = Location.builder()
+                .locationName("아이티센터")
+                .latitude(37.5665)
+                .longitude(126.9780)
+                .build();
+
+        Location destination = Location.builder()
+                .locationName("양재역")
+                .latitude(37.4837)
+                .longitude(127.0354)
+                .build();
+
+        shuttle = Shuttle.builder()
+                .shuttleName("양재 셔틀")
+                .departure(departure)
+                .destination(destination)
+                .isCommute(true)
+                .build();
+    }
+
+    @Test
+    @DisplayName("노선 목록 조회 단위 테스트")
+    void testGetShuttleList() {
+
+        when(shuttleRepository.findAll()).thenReturn(List.of(shuttle));
+
+        List<ShuttleResponseDto> result = shuttleService.getShuttleList();
+
+        assertThat(result).hasSize(1);
+        ShuttleResponseDto dto = result.getFirst();
+        assertThat(dto.getShuttleName()).isEqualTo("양재 셔틀");
+        assertThat(dto.getDepartureName()).isEqualTo("아이티센터");
+        assertThat(dto.getDestinationName()).isEqualTo("양재역");
+        assertThat(dto.getCommute()).isTrue();
+    }
+
+    @Test
+    @DisplayName("노선 위치 정보 포함 목록 조회 단위 테스트")
+    void testGetShuttleWithLocation() {
+
+        when(shuttleRepository.findAll()).thenReturn(List.of(shuttle));
+
+        List<ShuttleWithLocationResponseDto> result = shuttleService.getShuttleWithLocation();
+
+        assertThat(result).hasSize(1);
+        ShuttleWithLocationResponseDto dto = result.getFirst();
+        assertThat(dto.getDepartureName()).isEqualTo("아이티센터");
+        assertThat(dto.getDepartureLatitude()).isEqualTo(37.5665);
+        assertThat(dto.getDepartureLongitude()).isEqualTo(126.9780);
+        assertThat(dto.getDestinationName()).isEqualTo("양재역");
+        assertThat(dto.getDestinationLatitude()).isEqualTo(37.4837);
+        assertThat(dto.getDestinationLongitude()).isEqualTo(127.0354);
+        assertThat(dto.getCommute()).isTrue();
+    }
+}

--- a/seurasaeng_be/src/test/java/onehajo/seurasaeng/shuttle/TimetableIntegrationTest.java
+++ b/seurasaeng_be/src/test/java/onehajo/seurasaeng/shuttle/TimetableIntegrationTest.java
@@ -1,0 +1,100 @@
+package onehajo.seurasaeng.shuttle;
+
+import onehajo.seurasaeng.entity.Location;
+import onehajo.seurasaeng.entity.Shuttle;
+import onehajo.seurasaeng.entity.Timetable;
+import onehajo.seurasaeng.shuttle.repository.LocationRepository;
+import onehajo.seurasaeng.shuttle.repository.ShuttleRepository;
+import onehajo.seurasaeng.shuttle.repository.TimetableRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalTime;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@Transactional
+public class TimetableIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ShuttleRepository shuttleRepository;
+
+    @Autowired
+    private LocationRepository locationRepository;
+
+    @Autowired
+    private TimetableRepository timetableRepository;
+
+    @BeforeEach
+    void setUp() {
+        // 출발지, 도착지
+        Location departure = locationRepository.save(Location.builder()
+                .locationName("정부과천청사역")
+                .latitude(37.4254)
+                .longitude(126.9892)
+                .build());
+
+        Location destination = locationRepository.save(Location.builder()
+                .locationName("아이티센타워")
+                .latitude(37.5013)
+                .longitude(127.0396)
+                .build());
+
+        // Shuttle (출근)
+        Shuttle shuttle = shuttleRepository.save(Shuttle.builder()
+                .shuttleName("정부과천청사")
+                .departure(departure)
+                .destination(destination)
+                .isCommute(true)
+                .build());
+
+        // Timetable
+        timetableRepository.save(Timetable.builder()
+                .shuttle(shuttle)
+                .departureTime(LocalTime.of(7, 20))
+                .boardingLocation("7번출구 앞")
+                .dropoffLocation("G동 도로 옆")
+                .arrivalMinutes(15)
+                .totalSeats(45)
+                .build());
+    }
+
+    @Test
+    @DisplayName("시간표 목록 조회 API - 통합테스트 | 데이터 존재 시 200 OK")
+    void getTimetableSuccess() throws Exception {
+        mockMvc.perform(get("/api/timetables")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.commute[0].shuttleName").value("과천-센타워 셔틀"))
+                .andExpect(jsonPath("$.commute[0].spotName").value("정부과천청사역"))
+                .andExpect(jsonPath("$.commute[0].boardingPoint").value("7번출구 앞"))
+                .andExpect(jsonPath("$.commute[0].duration").value("15분"))
+                .andExpect(jsonPath("$.commute[0].totalSeats").value("45명"));
+    }
+
+    @Test
+    @DisplayName("시간표 목록 조회 API - 통합테스트 | 데이터 없을 시 204 No Content")
+    void getTimetableNoContent() throws Exception {
+        // 데이터 삭제
+        timetableRepository.deleteAll();
+        shuttleRepository.deleteAll();
+        locationRepository.deleteAll();
+
+        mockMvc.perform(get("/api/timetables")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNoContent());
+    }
+}

--- a/seurasaeng_be/src/test/java/onehajo/seurasaeng/shuttle/TimetableServiceUnitTest.java
+++ b/seurasaeng_be/src/test/java/onehajo/seurasaeng/shuttle/TimetableServiceUnitTest.java
@@ -1,0 +1,81 @@
+package onehajo.seurasaeng.shuttle;
+
+import onehajo.seurasaeng.entity.Location;
+import onehajo.seurasaeng.entity.Shuttle;
+import onehajo.seurasaeng.entity.Timetable;
+import onehajo.seurasaeng.shuttle.dto.TimetableResponseDto;
+import onehajo.seurasaeng.shuttle.repository.ShuttleRepository;
+import onehajo.seurasaeng.shuttle.repository.TimetableRepository;
+import onehajo.seurasaeng.shuttle.service.TimetableService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TimetableServiceUnitTest {
+
+    @InjectMocks
+    private TimetableService timetableService;
+
+    @Mock
+    private ShuttleRepository shuttleRepository;
+
+    @Mock
+    private TimetableRepository timetableRepository;
+
+    @Test
+    @DisplayName("시간표 목록 조회 API - 단위테스트")
+    void getCommuteTimetableSuccess() {
+        // Given
+        Location departure = Location.builder()
+                .locationName("정부과천청사역")
+                .build();
+
+        Location destination = Location.builder()
+                .locationName("아이티센타워")
+                .build();
+
+        Shuttle shuttle = Shuttle.builder()
+                .id(1L)
+                .shuttleName("과천-센타워 셔틀")
+                .departure(departure)
+                .destination(destination)
+                .isCommute(true)
+                .build();
+
+        Timetable timetable = Timetable.builder()
+                .shuttle(shuttle)
+                .departureTime(LocalTime.of(7, 20))
+                .boardingLocation("7번출구 앞")
+                .dropoffLocation("센타워 정문")
+                .arrivalMinutes(15)
+                .totalSeats(45)
+                .build();
+
+
+        when(shuttleRepository.findByIsCommute(true)).thenReturn(List.of(shuttle));
+        when(timetableRepository.findByShuttleOrderByDepartureTimeAsc(shuttle)).thenReturn(List.of(timetable));
+
+
+        TimetableResponseDto response = timetableService.getTimetable();
+
+        assertThat(response).isNotNull();
+        assertThat(response.getCommute()).hasSize(1);
+        assertThat(response.getCommute().getFirst().getShuttleName()).isEqualTo("과천-센타워 셔틀");
+        assertThat(response.getCommute().getFirst().getSpotName()).isEqualTo("정부과천청사역");
+        assertThat(response.getCommute().getFirst().getBoardingPoint()).isEqualTo("7번출구 앞");
+        assertThat(response.getCommute().getFirst().getDuration()).isEqualTo("15분");
+        assertThat(response.getCommute().getFirst().getTotalSeats()).isEqualTo("45명");
+
+        verify(shuttleRepository, times(1)).findByIsCommute(true);
+    }
+}


### PR DESCRIPTION
- ShuttleRepository 위치 변경 (qr 도메인 에서 shuttle 도메인으로 옮겼습니다)
- shuttle entity와 location entity 1:1 -> N:1 로 변경 (erd도 변경 완료) 

- 구현 API
  - 노선 목록 조회 API (통합테스트 완료, 단위테스트 완료)
  - 위치 정보 포함 노선 목록 조회 API (통합테스트 완료, 단위테스트 완료)
  - 시간표 목록 조회 API (통합테스트 완료, 단위테스트 완료)
  - 시간표 수정 API (통합테스트 완료, 단위테스트 완료)
  - 즐겨찾기 노선 조회 API (통합테스트 완료, 단위테스트 완료)
